### PR TITLE
Remove unnecessary 'generate_pagination' filter

### DIFF
--- a/addons/auto-pagination/auto-pagination-functions.php
+++ b/addons/auto-pagination/auto-pagination-functions.php
@@ -26,7 +26,6 @@ class SH_AutoPag_Functions {
         add_action('wp_head', array($this, 'remove_nextpage'));
         add_filter('get_the_excerpt', array($this, 'generate_excerpt'), 1);
         add_filter('the_content', array($this, 'add_pagination'), 51);
-        add_filter( 'generate_pagination', function( $output, $page, $pages, $args ) { return $output; }, 10, 4 );
         add_action('wp_enqueue_scripts', array($this, 'add_pagination_style'));
 		add_action( 'add_meta_boxes', array( $this, 'pagination_metabox' ) );
 		add_action( 'save_post', array($this,'pagination_metabox_render_save') );

--- a/addons/auto-pagination/auto-pagination-functions.php
+++ b/addons/auto-pagination/auto-pagination-functions.php
@@ -26,7 +26,7 @@ class SH_AutoPag_Functions {
         add_action('wp_head', array($this, 'remove_nextpage'));
         add_filter('get_the_excerpt', array($this, 'generate_excerpt'), 1);
         add_filter('the_content', array($this, 'add_pagination'), 51);
-        add_filter('generate_pagination', create_function('$output,$page,$pages,$args', 'return $output;'), 10, 4);
+        add_filter( 'generate_pagination', function( $output, $page, $pages, $args ) { return $output; }, 10, 4 );
         add_action('wp_enqueue_scripts', array($this, 'add_pagination_style'));
 		add_action( 'add_meta_boxes', array( $this, 'pagination_metabox' ) );
 		add_action( 'save_post', array($this,'pagination_metabox_render_save') );

--- a/addons/auto-pagination/auto-pagination-functions.php
+++ b/addons/auto-pagination/auto-pagination-functions.php
@@ -33,7 +33,7 @@ class SH_AutoPag_Functions {
     }
 
     public function get_default_args() {
-        
+
 		$args = array();
         $args['before'] = '<p>Pages:';
         $args['after'] = '</p>';
@@ -49,7 +49,7 @@ class SH_AutoPag_Functions {
         $args['link_wrapper_class'] = '';
         $args['link_wrapper_outter'] = '';
         $args['link_wrapper_outter_class'] = '';
-		
+
 		return $args;
     }
 
@@ -60,15 +60,15 @@ class SH_AutoPag_Functions {
 
     public function remove_nextpage() {
         global $post, $sh_page_links;
-        
+
         if (!$post->post_content || $post->post_content == '')
             return;
-            
+
         $options =  $sh_page_links->get_options();
-		
+
 		$option = get_post_meta($post->ID,"single_override_pagination",true);
         $ignore = false;
-        
+
 		if ($option == false || $option == "default" || $option == '') {
 			if (isset($options['auto_pagination']) && $options['auto_pagination'] == 1)
 				$ignore = true;
@@ -76,7 +76,7 @@ class SH_AutoPag_Functions {
 			if ($option == "ignore")
 				$ignore = true;
         }
-        
+
 		if ($ignore) {
             $post->post_content = str_replace("<!--nextpage-->", "", $post->post_content);
         } else {
@@ -121,12 +121,12 @@ class SH_AutoPag_Functions {
         <input type="checkbox" id="single_not_paginate" name="single_not_paginate" value="yes" <?php checked( 'yes', $value, true ); ?> /><label for="single_not_paginate"><?php _e("Don't paginate this", SH_PAGE_LINKS_DOMAIN); echo ' ' . strtolower($ptype); ?></label>
 		<?php
 	}
-	
+
     public function pagination_metabox_render_save($post_id) {
-		
+
 		if ( ! isset( $_POST['pagination_override'] ) || ! wp_verify_nonce( $_POST['pagination_override'], plugin_basename( __FILE__ ) ) )
 			return;
-		
+
 		update_post_meta($post_id, 'single_override_pagination', $_POST['single_override_pagination']);
 		update_post_meta($post_id, 'single_not_paginate', $_POST['single_not_paginate']);
 	}
@@ -156,7 +156,7 @@ class SH_AutoPag_Functions {
             $text = wp_trim_words( $text, $excerpt_length, $excerpt_more );
 
         }
-        
+
         return $text;
     }
 
@@ -177,26 +177,26 @@ class SH_AutoPag_Functions {
             return $content;
 
 		$options = $sh_page_links->get_options();
-		
+
         $content = str_replace("<!--nextpage-->", "", $content);
-		
+
         $post_type = get_post_type($post);
 		$enabled = unserialize($options['single_view']['enabled_posts']);
 		if (!in_array($post_type, $enabled))
 			return $content;
-		
+
         $auto_paged = 0;
-        
+
 		$elipsis = $options['scrolling_pagination']['elipsis'];
 		$firstpage = $options['scrolling_pagination']['firstpage'];
 		$lastpage = $options['scrolling_pagination']['lastpage'];
-		
+
         $auto_options = $options['auto_pagination'];
         $pages_array = $this->get_pages($content, $auto_options);
-		
+
         $pages = count($pages_array);
         $pages_count = $pages;
-		
+
         if ($pages > 1) {
             $auto_paged = 1;
             $page = (is_single() || is_page()) ? get_query_var('page') : 0;
@@ -206,9 +206,9 @@ class SH_AutoPag_Functions {
             $singlepage = !empty($_GET['singlepage']) ? 1 : 0;
             if (! ($singlepage==1 && $options['pagination_styles']['use_ajax']==0))
                 $output = $this->generate_pagination($page, $pages, $page_style_args, $elipsis);
-			
+
 			$wrapper_tag_output = "%s";
-			
+
 			/*
              * Add Single View
              */
@@ -219,11 +219,11 @@ class SH_AutoPag_Functions {
                 else
                     $wrapper_tag_output .= $sh_single_view->add_single_page('','','');
             }
-			
+
             if (! ($singlepage==1 && $options['pagination_styles']['use_ajax']==0)) {
 
                 if (!empty($page_style_args['wrapper_tag'])) {
-                        
+
                     $wrapper_tag = $page_style_args['wrapper_tag'];
                     $wrapper_id = empty($page_style_args['wrapper_id']) ? "" : " id=\"{$page_style_args['wrapper_id']}\"";
                     $wrapper_class = empty($page_style_args['wrapper_class']) ? " class=\"auto-paginate-links\"" : " class=\"auto-paginate-links {$page_style_args['wrapper_class']}\"";
@@ -234,7 +234,7 @@ class SH_AutoPag_Functions {
                             . "</". $wrapper_tag .">";
                 } else {
                     $after = isset($page_style_args['single']) ? $page_style_args['single'] : $page_style_args['after'];
-                    $wrapper_tag_output = 
+                    $wrapper_tag_output =
                             $page_style_args['before']
                             . $wrapper_tag_output
                             . $after;
@@ -243,19 +243,19 @@ class SH_AutoPag_Functions {
             } else {
 
                 if (!empty($page_style_args['wrapper_tag'])) {
-                        
+
                     $wrapper_tag = $page_style_args['wrapper_tag'];
                     $wrapper_id = empty($page_style_args['wrapper_id']) ? "" : " id=\"{$page_style_args['wrapper_id']}\"";
                     $wrapper_class = empty($page_style_args['wrapper_class']) ? " class=\"auto-paginate-links\"" : " class=\"auto-paginate-links {$page_style_args['wrapper_class']}\"";
                     $wrapper_tag_output = "<". $wrapper_tag ." ". $wrapper_id ." ". $wrapper_class .">"
                             . $wrapper_tag_output
                             . "</". $wrapper_tag .">";
-                }                
+                }
 
             }
 
 			$output = sprintf($wrapper_tag_output, $output);
-			
+
             global $current_page;
             $page_key = 0;
             if ($page > 0) {
@@ -273,7 +273,7 @@ class SH_AutoPag_Functions {
 
             if ($current_page === null)
                 $content = $content . $output;
-			
+
         }
         return $content;
     }
@@ -299,10 +299,10 @@ class SH_AutoPag_Functions {
 
         // check if page already has <!--nextpage-->
         if (substr_count($content, "<!--nextpage-->") !== 0) {
-			
+
 			$content_array = explode("<!--nextpage-->", $content);
-			
-            return $content_array; 
+
+            return $content_array;
         }
         $exploded_content = explode("\n", $content);
         $paragraph_count = 0;
@@ -316,11 +316,11 @@ class SH_AutoPag_Functions {
                 $paragraph_count++;
             }
         }
-		
+
         if ($options['break_type'] == 0) {
 
             //Break per paragraph
-            $modified_exploded_content = $content_pages;        
+            $modified_exploded_content = $content_pages;
             $options['total_paras']=count($modified_exploded_content);
             array_walk($modified_exploded_content, array($this, 'walker_insert_nextpage'), $options);
 
@@ -356,7 +356,7 @@ class SH_AutoPag_Functions {
             }
 
         } elseif ($options['break_type'] == 2) {
-            
+
             //Break per number of words
             $words_count = (int)$options['paragraph_count'];
             if ( (!$words_count) || ($words_count < 50) )
@@ -378,7 +378,7 @@ class SH_AutoPag_Functions {
         }
 
         $paged_content = implode("\n", $modified_exploded_content);
-        $page_content_array = explode("<!--sh_nextpage-->", $paged_content);    
+        $page_content_array = explode("<!--sh_nextpage-->", $paged_content);
         $page_content_array = array_filter($page_content_array,array($this, 'filter_trim'));
         return $page_content_array;
     }
@@ -395,15 +395,15 @@ class SH_AutoPag_Functions {
      */
      public function generate_pagination($page, $pages, $args, $elipsis) {
 		global $singlepage;
-		
+
 		if (!$args) {
 			$args = $this->get_default_arguments();
 		}
-		
+
         if ($page == 0)
             $page = 1;
         $output = "";
-        
+
         $singlepage = !empty($_GET['singlepage']) ? 1 : 0;
         if ($singlepage==1 && $options['pagination_styles']['use_ajax']==0) {
             return "";
@@ -421,7 +421,7 @@ class SH_AutoPag_Functions {
                 $link_html_close = '</a>';
             }
 
-			
+
             // Link Wrapper Inner
             $link_wrapper_open = "";
             $link_wrapper_close = "";
@@ -444,10 +444,10 @@ class SH_AutoPag_Functions {
                     $link_wrapper_outter_open = "<{$link_wrapper}{$link_class}>";
                     $link_wrapper_outter_close = "</{$link_wrapper}>";
                 }
-                
+
             }
 
-			
+
             $link_html_formatted = " "
                     . $link_wrapper_outter_open
 					. $link_html_open
@@ -457,17 +457,17 @@ class SH_AutoPag_Functions {
                     . $link_html_close
                     . $link_wrapper_outter_close
 					. " ";
-                  
+
 			if ($i != $pages)
 				$link_html_formatted .= $args['seperator'];
-			
+
 			if($i > 3)
 				$link_html_formatted .= $elipsis;
-				
-			
+
+
             $output .= $link_html_formatted;
         }
-		
+
         return apply_filters('generate_pagination', $output, $page, $pages, $args, $elipsis);
     }
 
@@ -494,7 +494,7 @@ class SH_AutoPag_Functions {
     }
 
 
-    
+
      /**
      * Filter method for trimming strings.
      *
@@ -533,7 +533,7 @@ class SH_AutoPag_Functions {
     /**
      * Retrieve default arguments from Pagination Styles
      *
-     * 
+     *
      * @return array
      */
     public function get_default_arguments() {
@@ -542,16 +542,16 @@ class SH_AutoPag_Functions {
 			global $sh_pagstyles_functions;
             $page_styles_args = apply_filters('wp_link_pages_args', $sh_pagstyles_functions->add_arg_values(array()));
 		} else {
-			
+
 			$page_styles_defaults = $this->get_default_args();
             $page_styles_args = apply_filters('wp_link_pages_args', $page_styles_defaults);
-            
+
         }
         return $page_styles_args;
     }
 
 
-    
+
     /**
      * Checks if Pagination Styles is active
      *
@@ -560,6 +560,6 @@ class SH_AutoPag_Functions {
     private function _has_pag_styles() {
         return class_exists('SH_PageLinks_PagStyles_Bootstrap');
     }
-	
-	
+
+
 }

--- a/addons/auto-pagination/auto-pagination-options.php
+++ b/addons/auto-pagination/auto-pagination-options.php
@@ -26,10 +26,10 @@ class SH_AutoPag_Options
     {
         add_action("sh_page_links_options_option_fields", array($this, 'options_fields'), 12);
         add_action("sh_page_links_options_option_sections", array($this, 'options_sections'), 12);
-		
+
 		add_action('admin_menu', array($this, 'admin_menu'), 12);
     }
-	
+
 
 
 	public function admin_menu() {
@@ -43,7 +43,7 @@ class SH_AutoPag_Options
 			array($this, 'show_menu_page')
 		);
 	}
-	
+
 
 
 	/**
@@ -104,7 +104,7 @@ class SH_AutoPag_Options
         return array_merge((array)$options, $new_options);
     }
 
-    
+
     /**
      * Defines Options page sections
      *

--- a/addons/auto-pagination/auto-pagination.php
+++ b/addons/auto-pagination/auto-pagination.php
@@ -71,7 +71,7 @@ class SH_PageLinks_AutoPag_Bootstrap {
     public static function init() {
 
         global $sh_autopag_options, $sh_autopag_functions;
-        
+
         $sh_autopag_options = new SH_AutoPag_Options();
         $sh_autopag_functions = new SH_AutoPag_Functions();
 
@@ -87,11 +87,11 @@ class SH_PageLinks_AutoPag_Bootstrap {
      */
     public static function set_options() {
         $options = get_option('sh_page_links_options');
-		
+
         if (empty($options['auto_pagination'])) {
             $options['auto_pagination'] = self::get_default_options();
-        }		
-		
+        }
+
         self::$options = $options;
     }
 
@@ -103,7 +103,7 @@ class SH_PageLinks_AutoPag_Bootstrap {
      * @return array
     */
     public function get_options() {
-	
+
         return self::$options;
     }
 

--- a/addons/pagination-styles/pagination-styles-functions.php
+++ b/addons/pagination-styles/pagination-styles-functions.php
@@ -39,7 +39,7 @@ class SH_PagStyles_Functions
      */
     public function add_arg_values($link_pages_args)
     {
-        
+
         global $sh_page_links, $auto_paged, $singlepage, $count, $sh_autopag_functions;
 
         $options     = $sh_page_links->get_options();
@@ -111,7 +111,7 @@ class SH_PagStyles_Functions
         }
         return $link;
     }
-    
+
     /**
      * Add pagination spacing.
      *
@@ -127,7 +127,7 @@ class SH_PagStyles_Functions
     </style>
     <?php
     }
-    
+
     /**
      * Add pagination by Ajax
      *
@@ -145,7 +145,7 @@ class SH_PagStyles_Functions
         $enabled = unserialize($options['single_view']['enabled_posts']);
         if (!in_array($post_type, $enabled))
             return $content;
-        
+
         if ($options['pagination_styles']['use_ajax']==1) {
 
             $id = $options['pagination_styles']['wrapper_id'];
@@ -174,7 +174,7 @@ class SH_PagStyles_Functions
                     //Load when the page is smaller than window
                     //Load when the scroll is at end of window
                     if ( ( current_h > content_end - 100) || ( page_h < total_h ) || (current_h+total_h >= page_h)) {
-                        
+
                         var next_page = $("#plp_ajax_current_page").val();
                         if (next_page != "hold") {
                             $("#plp_ajax_current_page").val("hold");
@@ -197,7 +197,7 @@ class SH_PagStyles_Functions
                                 });
                             });
                         }
-                    } 
+                    }
                 });
             });
             </script>
@@ -229,7 +229,7 @@ class SH_PagStyles_Functions
 
                         if ($(this).attr("data-ajax") == "0")
                             return;
-                        
+
                         e.preventDefault();
                         var pagination = $(this).attr("href");
 
@@ -300,7 +300,7 @@ class SH_PagStyles_Functions
 
         return $content;
     }
-    
+
     /**
      * Return next page for ajax
      *
@@ -337,9 +337,9 @@ class SH_PagStyles_Functions
         $content = apply_filters( 'the_content', $current_post->post_content );
 
         if ($sh_autopag_functions) {
-            
+
             global $post;
-            
+
             $post = $current_post;
             $sh_autopag_functions->remove_nextpage();
             setup_postdata( $post );
@@ -352,9 +352,9 @@ class SH_PagStyles_Functions
                     global $pages_count;
                     $page_style_args = $options['pagination_styles'];
                     echo $sh_scrolling_functions->generate_scrolling_pagination("", $current_page+1, $pages_count, $page_style_args, "plp_new_pagination");
-                }    
+                }
             }
-            
+
 
         } else {
             //No auto pagination. Just Single pagination.
@@ -367,6 +367,6 @@ class SH_PagStyles_Functions
         }
 
         die();
-        
+
     }
 }

--- a/addons/pagination-styles/pagination-styles-options.php
+++ b/addons/pagination-styles/pagination-styles-options.php
@@ -15,13 +15,13 @@
 class SH_PagStyles_Options
 {
     public function __construct()
-    {	
+    {
         add_action("sh_page_links_options_option_fields", array($this, 'options_fields'), 11);
         add_action("sh_page_links_options_option_sections", array($this, 'options_sections'), 11);
-		
+
 		add_action('admin_menu', array($this, 'admin_menu'), 11);
     }
-	
+
 	public function admin_menu() {
 		// Add new menu option
 		add_submenu_page(
@@ -33,7 +33,7 @@ class SH_PagStyles_Options
 			array($this, 'show_menu_page')
 		);
 	}
-	
+
 	/**
      * Display options page
      * @return void
@@ -114,7 +114,7 @@ class SH_PagStyles_Options
                                         SH_PAGE_LINKS_DOMAIN),
                     'callback'    => array('SH_PageLinks_Options', 'settings_field_cb'),
                 ),
-				
+
 				'header' => array(
                     'id'      => 'header',
                     'title'   => '<p class="p-header-2"><strong>' . __('Styles', SH_PAGE_LINKS_DOMAIN) .'</strong></p>',
@@ -128,7 +128,7 @@ class SH_PagStyles_Options
                     'default' => '1',
                     'description' => __('Echo (1) or return (0) the page list. Defaults to "1" (echo).', SH_PAGE_LINKS_DOMAIN),
                     'callback' => array('SH_PageLinks_Options', 'settings_field_cb'),
-                ),  
+                ),
 				'seperator' => array(
                     'id'      => 'seperator',
                     'title'   => __('Pagination Separator', SH_PAGE_LINKS_DOMAIN),
@@ -137,7 +137,7 @@ class SH_PagStyles_Options
                     'default' => '|',
                     'description' => __('Pagination separator. Defaults to " | ".', SH_PAGE_LINKS_DOMAIN),
                     'callback' => array('SH_PageLinks_Options', 'settings_field_cb'),
-                ),                 
+                ),
 				'wrapper_tag' => array(
                     'id'      => 'wrapper-tag',
                     'title'   => __('Page Links Wrapper Element', SH_PAGE_LINKS_DOMAIN),
@@ -231,7 +231,7 @@ class SH_PagStyles_Options
      */
     public function options_sections($sections = array())
     {
-        
+
         $new_sections = array(
             'pagination_styles' => array(
                 'title' => __('Pagination Controls', SH_PAGE_LINKS_DOMAIN),

--- a/addons/pagination-styles/pagination-styles.php
+++ b/addons/pagination-styles/pagination-styles.php
@@ -50,7 +50,7 @@ class SH_PageLinks_PagStyles_Bootstrap
      *
      * @var array
      */
-	
+
     protected static $default_options = array(
         'before'             => '<p>Pages:',
         'after'              => '</p>',
@@ -65,7 +65,7 @@ class SH_PageLinks_PagStyles_Bootstrap
         'link_wrapper_class' => '',
         'pagelink'           => '%',
         'archive_pages'      => 0,
-		
+
     );
 
     /**
@@ -81,7 +81,7 @@ class SH_PageLinks_PagStyles_Bootstrap
 		$sh_pagstyles_functions = new SH_PagStyles_Functions();
 
     }
-    
+
 
     /**
      * Set plugin options. This method should run every time

--- a/addons/scrolling-pagination/scrolling-pagination-functions.php
+++ b/addons/scrolling-pagination/scrolling-pagination-functions.php
@@ -20,7 +20,7 @@ class SH_ScrollingPagination_Functions {
     public function __construct() {
         add_filter('generate_pagination', array($this, 'generate_scrolling_pagination'), 10, 4);
     }
-    
+
     /**
      * Generates the scrolling pagination list.
      *
@@ -31,10 +31,10 @@ class SH_ScrollingPagination_Functions {
      *
      * @return string
      */
-	 
+
     public function generate_scrolling_pagination($content, $page, $pages, $args, $spanid = "plp_inital_pagination") {
         global $sh_page_links, $auto_paged, $singlepage, $sh_autopag_functions, $scrolling_paged;
-		
+
         $scrolling_paged = 0;
         if (!$auto_paged || ($pages < 1))
             return $content;
@@ -48,7 +48,7 @@ class SH_ScrollingPagination_Functions {
         if ($scrolls < 1)
             return $content;
         $content = "";
-	
+
         //
         // generate our scrolling navigation...
         // Start with prev/next links
@@ -56,7 +56,7 @@ class SH_ScrollingPagination_Functions {
         $prev_link = "";
         $next_link = "";
         if (!$singlepage) {
-			
+
 			$first_num = 1;
 			$first_num = ' '
 						. $r['link_before_outter']
@@ -68,7 +68,7 @@ class SH_ScrollingPagination_Functions {
 						. $r['link_after_outter']
 						. ' '
 						. $args['seperator'];
-			
+
 			$prev_link = "";
             if ($page > 1) {
                 $prev_num = $page - 1;
@@ -77,13 +77,13 @@ class SH_ScrollingPagination_Functions {
 						. sh_wp_link_page($prev_num, $r['previouspageclass'])
 						. $r['link_before']
                         . $r['previouspagelink']
-                        . $r['link_after'] 
+                        . $r['link_after']
 						. '</a>'
 						. $r['link_after_outter']
 						. ' '
 						. $args['seperator'];
             }
-			
+
 			$next_link = "";
             if ($page < $pages) {
                 $next_num = $page + 1;
@@ -92,13 +92,13 @@ class SH_ScrollingPagination_Functions {
 						. sh_wp_link_page($next_num, $r['nextpageclass'])
 						. $r['link_before']
                         . $r['nextpagelink']
-                        . $r['link_after'] 
+                        . $r['link_after']
 						. '</a>'
 						. $r['link_after_outter']
 						. ' '
 						. $args['seperator'];
             }
-			
+
 			$last_num = $pages;
             $last_num = ' '
 						. $r['link_before_outter']
@@ -108,10 +108,10 @@ class SH_ScrollingPagination_Functions {
 						. $r['link_after']
                         . '</a>'
 						. $r['link_after_outter'];
-						
+
         }
         $output = "";
-		
+
 		// Set defaults...
 		$link_wrapper_open = "";
 		$link_wrapper_close = "";
@@ -126,7 +126,7 @@ class SH_ScrollingPagination_Functions {
 				$link_wrapper_close = "</{$link_wrapper}>";
 			}
 		}
-		
+
 		//Calculating start depending of limit
 		if ($pages_per_scroll == 1) {
 			$start = $page;
@@ -157,23 +157,23 @@ class SH_ScrollingPagination_Functions {
 			}
 			$end--;
 		}
-		
+
 		//Adding ellipsis to start
 		if ($start > 1)
 			$output .= 	" "
 						. $r['elipsis']
 						. " "
 						. $args['seperator'];
-		
-		
+
+
 		$title = get_the_title();
 		for ($i = $start; $i <= ($end); $i++) {
-			
+
             $link_html = _wp_link_page($i);
-			
+
             $current_class = ($i == $page) ? 'current' : '';
             if ( ($options['pagination_styles']['use_ajax']!=0) || ( $i != $page || $singlepage ) ) {
-			
+
 			 	$link_html_formatted = " "
 				 		. $r['link_before_outter']
 						. $link_html
@@ -184,7 +184,7 @@ class SH_ScrollingPagination_Functions {
 						. $r['link_after_outter']
 						. " "
 						. $args['seperator'];
-					
+
 			} else {
 				$link_html_formatted = 	$r['link_before_outter']
 										. '<span class="plp-active-page">'
@@ -192,11 +192,11 @@ class SH_ScrollingPagination_Functions {
 										. "</span> "
 										. $r['link_after_outter']
 										. $args['seperator'];
-				
+
 			}
             $output .= $link_html_formatted;
         }
-		
+
 		//Adding ellipsis to end
 		if ($end < $pages)
 			$output .= 	" "

--- a/addons/scrolling-pagination/scrolling-pagination-options.php
+++ b/addons/scrolling-pagination/scrolling-pagination-options.php
@@ -21,10 +21,10 @@ class SH_ScrollingPagination_Options
     {
         add_action("sh_page_links_options_option_fields", array($this, 'options_fields'), 13);
         add_action("sh_page_links_options_option_sections", array($this, 'options_sections'), 13);
-		
+
 		add_action('admin_menu', array($this, 'admin_menu'), 13);
     }
-	
+
 	public function admin_menu() {
 		// Add new menu option
 		add_submenu_page(
@@ -36,7 +36,7 @@ class SH_ScrollingPagination_Options
 			array($this, 'show_menu_page')
 		);
 	}
-	
+
 	/**
      * Display options page
      * @return void
@@ -142,7 +142,7 @@ class SH_ScrollingPagination_Options
                         <div style="height:420px"></div>',
                     'callback' => array('SH_PageLinks_Options', 'settings_field_cb'),
                 ),
-				
+
             ),
         );
         return array_merge((array)$options, $new_options);

--- a/addons/scrolling-pagination/scrolling-pagination.php
+++ b/addons/scrolling-pagination/scrolling-pagination.php
@@ -62,14 +62,14 @@ class SH_PageLinks_ScrollingPagination_Bootstrap
     public static function init()
     {
         global $sh_scrolling_options, $sh_scrolling_functions, $auto_pag_active, $main_active;
-		
+
         $sh_scrolling_options   = new SH_ScrollingPagination_Options();
 		$sh_scrolling_functions = new SH_ScrollingPagination_Functions();
-		
-    }
-	
 
-    
+    }
+
+
+
     /**
      * Set plugin options. This method should run every time
      * plugin options are updated.
@@ -112,5 +112,5 @@ class SH_PageLinks_ScrollingPagination_Bootstrap
     {
         return array_merge((array)$new_options, self::$default_options);
     }
-	
+
 }

--- a/page-links-install.php
+++ b/page-links-install.php
@@ -71,9 +71,9 @@ class SH_PageLinks_Install
      * @return void
      */
     public static function do_deactivate()
-    {	 
+    {
         flush_rewrite_rules();
-		
+
 		// Action to deactivate optional modules
 		add_action('update_option_active_plugins', array('SH_PageLinks_Install','deactivate_dependents'));
    }
@@ -91,7 +91,7 @@ class SH_PageLinks_Install
 		);
 		deactivate_plugins($dependent);
 	}
-    
+
 
     /**
      * Returns default options

--- a/page-links-options.php
+++ b/page-links-options.php
@@ -46,7 +46,7 @@ class SH_PageLinks_Options
         add_action('admin_init', array($this, 'options_init'));
         add_action('admin_menu', array($this, 'admin_menu'));
     }
- 
+
     /**
      * admin_menu()
      * Hook function for admin_menu hook.
@@ -55,7 +55,7 @@ class SH_PageLinks_Options
      */
     public function admin_menu()
     {
-        
+
         global $menu_page;
         if (empty($menu_page)){
             $menu_page = add_menu_page(
@@ -78,7 +78,7 @@ class SH_PageLinks_Options
         }
         add_action( 'admin_enqueue_scripts', array($this, 'admin_styles') );
     }
- 
+
     /**
      * admin_styles()
      * Enqueue special style for admin
@@ -87,7 +87,7 @@ class SH_PageLinks_Options
      */
     public function admin_styles()
     {
-        
+
         return wp_enqueue_style( 'plp-global' );
     }
 
@@ -102,8 +102,8 @@ class SH_PageLinks_Options
     {
         wp_enqueue_script('jquery-ui', null, array('jquery'));
         wp_enqueue_script('jquery-ui-tabs', null, array('jquery'));
-		
-		wp_register_script('admin-menu-current', plugins_url('js/admin-menu-current.min.js', __FILE__),array('jquery'),SH_PAGE_LINKS_VER);	
+
+		wp_register_script('admin-menu-current', plugins_url('js/admin-menu-current.min.js', __FILE__),array('jquery'),SH_PAGE_LINKS_VER);
         wp_register_script('pagination_option_validation', plugins_url('js/pagination_option_validation.min.js', __FILE__),array('jquery'), SH_PAGE_LINKS_VER);
 
         wp_enqueue_script('admin-menu-current');
@@ -296,9 +296,9 @@ class SH_PageLinks_Options
 
             if ($option['type'] == 'multicheckcp') {
                 $cps =  get_post_types(array('public' => true), 'objects');
-                
+
                 try {
-                    @$value = unserialize($option_values[$option['section']][$option['name']]);  
+                    @$value = unserialize($option_values[$option['section']][$option['name']]);
                 } catch (Exception $e) {
                     $value = array('A');
                 }
@@ -312,7 +312,7 @@ class SH_PageLinks_Options
 
                     $i++;
                     $option_str_holder = "";
-                    
+
                     $checked = " ";
                     if (is_array($value))
                         if (in_array($cp->name, $value)) $checked = "CHECKED ";
@@ -342,9 +342,9 @@ class SH_PageLinks_Options
                         . "[{$option['name']}][]\" "
                         . "id=\"{$option['id']}_$i\" "
                         . "value=\"_empty_\" ";
-                            
+
             }
-            
+
             if ($option['type'] == 'text') {
                 $description = !empty($option['description'])
                             ? "<span class=\"description\">{$option['description']}</span>" : '';
@@ -362,7 +362,7 @@ class SH_PageLinks_Options
             }
 
             if ($option['type'] == 'phpstatus') {
-                
+
                 $option_str = '<div class="phpstatus">';
 
                 if (version_compare(PHP_VERSION, '5.3.0') >= 0) {
@@ -397,13 +397,13 @@ class SH_PageLinks_Options
                 }
 
                 $updates = get_site_transient('update_plugins');
-                
+
                 if (isset($updates->response['page-links-single-page-option/page-links.php'])) {
                     $option_str .= '<li class="false">' . __("Page Links Version", SH_PAGE_LINKS_DOMAIN) . ': <strong>' . SH_PAGE_LINKS_VER . '</strong> <em>'. __("New version available", SH_PAGE_LINKS_DOMAIN) . " : " . $updates->response['page-links-single-page-option/page-links.php']->new_version . '<a href="update-core.php">' . __("Update it!", SH_PAGE_LINKS_DOMAIN) .'</a></em></li>';
                 } else {
                     $option_str .= '<li>' . __("Page Links Version", SH_PAGE_LINKS_DOMAIN) . ': <strong>' . SH_PAGE_LINKS_VER . '</strong></li>';
                 }
-                
+
 
                 if (class_exists('SH_PageLinks_PagStyles_Bootstrap')) {
                     if (!isset($updates->response['pagination-styles/pagination-styles.php'])) {
@@ -431,12 +431,12 @@ class SH_PageLinks_Options
 
             }
         }
-        
+
         echo $option_str;
     }
 
 
-    
+
 	/**
 	 * Sanitizes option fields
 	 *
@@ -458,7 +458,7 @@ class SH_PageLinks_Options
             esc_attr($current_tab),
             'updated'
         );
-		
+
 		if ($options) {
 			foreach ($options as $option_section => $option) {
 				foreach ($option as $option_name => $option_value) {
@@ -476,16 +476,16 @@ class SH_PageLinks_Options
 									$value = ($newval < $minval) ? $minval : $newval;
 								}
 							break;
-							
+
 							case 'array':
-								
+
 								$data = @unserialize($option_value);
 								if ($data !== false) {
 									$value = $option_value;
 								} else {
 									$value = serialize($option_value);
 								}
-								
+
 							break;
 							default:
 								if ($field_data['valid'] == 'html'){
@@ -508,8 +508,8 @@ class SH_PageLinks_Options
         return $new_options;
 	}
 	public function reset_button() {
-	
+
 		$val =1;
 	 	return $val;
-	 } 
+	 }
 }

--- a/page-links.php
+++ b/page-links.php
@@ -32,19 +32,19 @@ define('SH_PAGE_LINKS_VER', '2.5.1');
  */
 global $sh_page_links, $sh_page_links_options;
  	// Add settings link on plugin page
-function single_page_styles($links) { 
-  $settings_link = '<a href="options-general.php?page=sh-page-links-options">'. __('Settings', SH_PAGE_LINKS_DOMAIN) .'</a>'; 
-  array_unshift($links, $settings_link); 
-  return $links; 
+function single_page_styles($links) {
+  $settings_link = '<a href="options-general.php?page=sh-page-links-options">'. __('Settings', SH_PAGE_LINKS_DOMAIN) .'</a>';
+  array_unshift($links, $settings_link);
+  return $links;
 }
-$plugin = plugin_basename(__FILE__); 
+$plugin = plugin_basename(__FILE__);
 add_filter("plugin_action_links_$plugin", 'single_page_styles' );
 
 
 function sh_wp_link_page($i, $class = '', $attr = '') {
 
     return str_replace('href=', $attr . ' class="'. $class .'" href=', _wp_link_page($i) );
-    
+
 }
 
 
@@ -80,7 +80,7 @@ class SH_PageLinks_Bootstrap {
     public static function init()
     {
         global $sh_page_links, $sh_singleview_options;
-        
+
         load_plugin_textdomain('page-links-single-page-option', false, dirname(plugin_basename(__FILE__)) . '/languages/');
 
         self::set_options();
@@ -104,9 +104,9 @@ class SH_PageLinks_Bootstrap {
             SH_PAGE_LINKS_VER,
             'screen'
         );
-        
+
         wp_register_style( 'plp-global', SH_PAGE_LINKS_URL . '/css/global.css', null, SH_PAGE_LINKS_VER, 'screen' );
-		
+
 		add_filter('transient_update_plugins', array($this, 'checkForUpdate'));
 		add_filter('site_transient_update_plugins', array($this, 'checkForUpdate'));
         $sh_page_links_options = new SH_PageLinks_Options();
@@ -139,22 +139,22 @@ class SH_PageLinks_Bootstrap {
     {
         return self::$options;
     }
-	
+
 	/**
 	 * Check for Updates
 	 *
-	 */	
+	 */
 	public function checkForUpdate($option) {
-		
-		
+
+
 		require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
         $gitUriValue = 'https://github.com/studiohyperset/page-links-single-page-option/';
-		
+
 		$url = 'https://api.github.com/repos/studiohyperset/page-links-single-page-option/tags';
-		
+
         $response = get_transient(md5($url)); // Note: WP transients fail if key is long than 45 characters
-        
+
 		if(empty($response)){
             $raw_response = wp_remote_get($url, array('sslverify' => false, 'timeout' => 10));
 			if ( is_wp_error( $raw_response ) ){
@@ -168,16 +168,16 @@ class SH_PageLinks_Bootstrap {
                 return $option;
             }
             $response = $response[0];
-			
+
 			//set cache
 			set_transient(md5($url), $response, 6000);
 		}
-		
+
         // check and generate download link
         $data = get_plugin_data( __FILE__ );
         $plugin = plugin_basename(__FILE__);
 		if(version_compare($data['Version'],  $response->name, '>=')){
-			// up-to-date!  
+			// up-to-date!
 			unset($option->response[$plugin]);
 		} else {
             $option->response[$plugin] = (object)array(

--- a/pages/page-plugin-options.php
+++ b/pages/page-plugin-options.php
@@ -18,7 +18,7 @@ if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF']))
     if (!empty($messages[0]['message'])) {
         $current_tab = $messages[0]['message'];
 	}
-	
+
 ?>
 <style type="text/css">
     #icon-sh-page-links-options {
@@ -26,7 +26,7 @@ if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF']))
     }
 </style>
 <script type="text/javascript">
-	 
+
     jQuery(function($){
 
     	$('#toplevel_page_sh-page-links-options ul li.wp-first-item a').attr('href', $('#toplevel_page_sh-page-links-options ul li.wp-first-item a').attr('href')+'#single_view');
@@ -40,7 +40,7 @@ if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF']))
                 $input.val(currentPanel);
             }
         });
-		
+
 		$(window).bind('hashchange', function () { //detect hash change
 			var hash = window.location.hash.slice(1); //hash to string (= "myanchor")
 			$('.nav-tab-wrapper li[aria-controls="'+hash+'"] a').click();
@@ -151,7 +151,7 @@ if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF']))
 		var firstpage = jQuery("#firstpage").val();
 		var lastpage = jQuery("#lastpage").val();
 		var sepval = jQuery("#seperator").val();
-		
+
 		//jQuery("#before-content-1").html(before);
 		jQuery("#wrapper-tag-1").html(wraptag);
 		jQuery("#wrapper-tag-2").html(wraptag);
@@ -199,7 +199,7 @@ if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF']))
 		jQuery("#sepval-6").html(sepval);
 		jQuery("#sepval-7").html(sepval);
 		jQuery("#sepval-8").html(sepval);
-		
+
 	});
 	jQuery(function (){
 		jQuery('#link-wrapper').change(function (){
@@ -218,63 +218,63 @@ if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF']))
 			jQuery("#link-wrapper-12").html(linkwrap);
 			jQuery("#link-wrapper-13").html(linkwrap);
 			jQuery("#link-wrapper-14").html(linkwrap);
-		 });       
+		 });
 	});
 	jQuery(function (){
 		jQuery('#wrapper-tag').change(function (){
 			var wraptag = jQuery("#wrapper-tag").val();
 			jQuery("#wrapper-tag-1").html(wraptag);
 			jQuery("#wrapper-tag-2").html(wraptag);
-		 });       
+		 });
 	});
 	jQuery(function (){
 		jQuery('#wrapper-id').change(function (){
 			var wrapid = jQuery("#wrapper-id").val();
 			//var wrapid = wrapid.replace(",", " ");
 			jQuery("#wrapper-id-1").html(wrapid);
-		});       
+		});
 	})
 	jQuery(function (){
 		jQuery('#wrapper-class').change(function (){
 			var wrapclass = jQuery("#wrapper-class").val();
 			var wrapclass = wrapclass.replace(",", " ");
 			jQuery("#wrapper-class-1").html(wrapclass);
-		});       
+		});
 	});
 	jQuery(function (){
 		jQuery('#nextpagelink').change(function (){
 			var nxtpaglink = jQuery("#nextpagelink").val();
 			jQuery("#nextpagelink-1").html(nxtpaglink);
 			jQuery("#nextpagelink-2").html(nxtpaglink);
-		});       
+		});
 	});
 	jQuery(function (){
 		jQuery('#previouspagelink').change(function (){
 			var prevpagelink = jQuery("#previouspagelink").val();
 			jQuery("#previouspagelink-1").html(prevpagelink);
 			jQuery("#previouspagelink-2").html(prevpagelink);
-		});       
+		});
 	});
 	jQuery(function (){
 		jQuery('#firstpage').change(function (){
 			var firstpage = jQuery("#firstpage").val();
 			jQuery("#firstpage-1").html(firstpage);
 			jQuery("#firstpage-2").html(firstpage);
-		});       
+		});
 	});
 	jQuery(function (){
 		jQuery('#lastpage').change(function (){
 			var lastpage = jQuery("#lastpage").val();
 			jQuery("#lastpage-1").html(lastpage);
 			jQuery("#lastpage-2").html(lastpage);
-		});       
+		});
 	});
 	jQuery(function (){
 		jQuery('#elipsis').change(function (){
 			var elipsis = jQuery("#elipsis").val();
 			jQuery("#elipsis-1").html(elipsis);
 			jQuery("#elipsis-2").html(elipsis);
-		});       
+		});
 	});
 	jQuery(function (){
 		jQuery('#link-wrapper-class').change(function (){
@@ -286,12 +286,12 @@ if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF']))
 			jQuery("#link-wrapper-class-5").html(linkwrapclass);
 			jQuery("#link-wrapper-class-6").html(linkwrapclass);
 			jQuery("#link-wrapper-class-7").html(linkwrapclass);
-		});       
+		});
 	});
-	
+
 </script>
 <div class="wrap">
-	
+
     <h2>Page-Links Plus</h2>
 	<div class="border"></div>
 	<div id="logo-content">
@@ -304,29 +304,29 @@ if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF']))
 	    </div>
 
 	    <div id="logo-right">
-	    
+
 		    <p><a href="http://studiohyperset.com" target="_blank">Studio Hyperset</a> <?php _e("built Page-Links Plus for one reason: to provide the WordPress community with an integrated, comprehensive pagination solution.", SH_PAGE_LINKS_DOMAIN); ?></p>
 		    <p><?php _e("Whether you're a WordPress developer, site manager, or lay user, Page-Links Plus can help you set up, customize, and manage your site's pagination quickly and easily.", SH_PAGE_LINKS_DOMAIN); ?></p>
-            
+
 
 
  <?php if (!is_plugin_active('pagination-styles/pagination-styles.php') || !is_plugin_active('auto-pagination/auto-pagination.php') || !is_plugin_active('scrolling-pagination/scrolling-pagination.php')) { echo '<div id="plp-in-two" class="rwd-media"><h3>PLP in :02</h3>
-<iframe src="//player.vimeo.com/video/109187562" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>'; } else { } ?>		    
+<iframe src="//player.vimeo.com/video/109187562" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>'; } else { } ?>
 
-		    
-	    
+
+
 	    </div>
 	</div>
 
 	<div class="breaker-bottom"></div>
-   
+
     <?php if (isset($_GET['settings-updated'])) : ?>
         <div id="setting-error-settings_updated" class="updated settings-error"><p><strong><?php _e("Settings saved.", SH_PAGE_LINKS_DOMAIN); ?></strong></p></div>
     <?php endif; ?>
     <form action="options.php" method="post" id="sh_pagelinks_options_form">
 
         <?php settings_fields('sh_page_links_options'); ?>
-        
+
         <div class="tabs">
 
             <div class="nav-tab-wrapper">
@@ -340,7 +340,7 @@ if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF']))
             </div>
 
             <?php foreach ($sections as $section_name): ?>
-				
+
 				 <div class="tab" id="<?php echo esc_attr($section_name); ?>">
 				 	<?php do_settings_sections("sh_page_links_options-{$section_name}"); ?>
                 </div>
@@ -350,6 +350,6 @@ if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF']))
         </div>
 
 		<input name="sh_page_links_option-submit" type="submit" class="button-primary" value="<?php esc_attr_e('Save Settings', SH_PAGE_LINKS_DOMAIN); ?>" />
-		<input type="button" class="button-primary" id="restorevalue" name="sh_page_links_option-reset" value="<?php esc_attr_e('Restore default', SH_PAGE_LINKS_DOMAIN); ?>"/> 
+		<input type="button" class="button-primary" id="restorevalue" name="sh_page_links_option-reset" value="<?php esc_attr_e('Restore default', SH_PAGE_LINKS_DOMAIN); ?>"/>
     </form>
 </div>

--- a/single-view/single-view-options.php
+++ b/single-view/single-view-options.php
@@ -54,7 +54,7 @@ class SH_PageLinks_SingleView_Options
                     'default' => 1,
                     'callback' => array('SH_PageLinks_Options', 'settings_field_cb')
                 ),
-                
+
                 'text_single_link' => array(
                     'id'      => 'text-single-link',
                     'title'   => __('\'Single Page\' Link Text', SH_PAGE_LINKS_DOMAIN),
@@ -64,7 +64,7 @@ class SH_PageLinks_SingleView_Options
                     'default' => 'Single Page',
                     'callback' => array('SH_PageLinks_Options', 'settings_field_cb')
                 ),
-				
+
                 'text_multiple_link' => array(
                     'id'      => 'text-multiple-link',
                     'title'   => __('\'Multi-Page\' Link Text', SH_PAGE_LINKS_DOMAIN),
@@ -74,13 +74,13 @@ class SH_PageLinks_SingleView_Options
                     'default' => 'Multi-Page',
                     'callback' => array('SH_PageLinks_Options', 'settings_field_cb')
                 ),
-				
+
 				'header' => array(
                     'id'      => 'header',
                     'title'   => '<div style="position:absolute; font-style:italic; font-weight: normal;">' . __('After enabling, users can also activate the single-page view by appending "?singlepage=1" to the end of any page or post (e.g., http://sampleurl.com/page-title?singlepage=1).', SH_PAGE_LINKS_DOMAIN) . '</div><div style="height:20px"></div>',
                     'callback' => array('SH_PageLinks_Options', 'settings_field_cb'),
                 ),
-                
+
                 'enabled_posts' => array(
                     'id'      => 'enabled-posts',
                     'title'   => $enable_title,
@@ -90,7 +90,7 @@ class SH_PageLinks_SingleView_Options
                     'default' => array('post', 'page'),
                     'callback' => array('SH_PageLinks_Options', 'settings_field_cb')
                 ),
-				
+
                 'phpstatus' => array(
                     'id'      => 'php-status',
                     'title'   => __('System Status:', SH_PAGE_LINKS_DOMAIN),
@@ -100,10 +100,10 @@ class SH_PageLinks_SingleView_Options
                     'default' => '',
                     'callback' => array('SH_PageLinks_Options', 'settings_field_cb')
                 ),
-				
+
             ),
         );
-		
+
         return array_merge($new_options, (array)$options);
     }
 
@@ -115,7 +115,7 @@ class SH_PageLinks_SingleView_Options
      */
     public function options_sections($sections = array())
     {
-        
+
         $new_sections = array(
             'single_view' => array(
                 'title' => __('Single Page', SH_PAGE_LINKS_DOMAIN),

--- a/single-view/single-view.php
+++ b/single-view/single-view.php
@@ -72,7 +72,7 @@ class SH_PageLinks_SingleView {
 
         return $newval;
     }
-	
+
 	/**
      * Separate the "Single Page" option, so extensions
 	 * may call it.
@@ -85,7 +85,7 @@ class SH_PageLinks_SingleView {
 	public function add_single_page($sep,$wrap_open,$wrap_close) {
 		global $sh_page_links;
 		$options = $sh_page_links->get_options();
-		
+
 		$singlepage = $singlepage = !empty($_GET['singlepage']) ? 1 : 0;
 
         if ($singlepage == 0) {
@@ -97,16 +97,16 @@ class SH_PageLinks_SingleView {
         }
 
 		$link = 	" "
-					. $sep 
-					. " " 
+					. $sep
+					. " "
 					. "<a data-ajax=\"0\" href=\"{$url}\">"
                     . $wrap_open
                     . $link_text
                     . $wrap_close
                     . "</a>";
-					
+
 		return $link;
-		
+
 	}
 
     /**
@@ -119,7 +119,7 @@ class SH_PageLinks_SingleView {
      * @return string
      */
     public function add_all_pages($content) {
-		
+
         global $multipage, $post, $auto_paged, $singlepage, $scrolling_paged;
 
         $singlepage = !empty($_GET['singlepage']) ? 1 : 0;


### PR DESCRIPTION
Hi,

We're using this plugin on our site and noticed a few notices.

This PR removes the `'generate_pagination'` filter since it isn't necessary because the anonymous function was already returning the default `$output` variable.

PR also trims whitespace throughout the codebase. See commit d5b298d.